### PR TITLE
Tflite onnx fix

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -124,6 +124,7 @@ def yolo_predict_tflite(interpreter, image, anchors, num_classes, conf_threshold
     for output_detail in output_details:
         output_data = interpreter.get_tensor(output_detail['index'])
         prediction.append(output_data)
+    prediction.sort(key=lambda x: len(x[0]))
 
     if len(anchors) == 5:
         # YOLOv2 use 5 anchors and have only 1 prediction
@@ -304,6 +305,7 @@ def yolo_predict_onnx(model, image, anchors, num_classes, conf_threshold):
 
     feed = {input_tensors[0].name: image_data}
     prediction = model.run(None, feed)
+    prediction.sort(key=lambda x: len(x[0]))
 
     if len(anchors) == 5:
         # YOLOv2 use 5 anchors and have only 1 prediction

--- a/tools/keras_to_onnx.py
+++ b/tools/keras_to_onnx.py
@@ -9,9 +9,13 @@ import argparse
 import shutil
 import subprocess
 from tensorflow.keras.models import load_model
-
+from tensorflow.keras import backend as K
 sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..'))
 from common.utils import get_custom_objects
+
+
+def mish(x):
+    return x * K.tanh(K.log(1 + K.exp(K.abs(-x))) + K.maximum(x, 0))
 
 
 def main():
@@ -21,7 +25,9 @@ def main():
     parser.add_argument('--op_set', required=False, type=int, help='onnx op set', default=10)
 
     args = parser.parse_args()
-    model = load_model(args.keras_model_file)
+    custom_ob_dict = get_custom_objects()
+    custom_ob_dict['mish'] = mish
+    model = load_model(args.keras_model_file, custom_objects=custom_object_dict)
     model.save('./tmp/')
 
     cmd = 'python -m tf2onnx.convert --saved_model ./tmp/ --output {} --opset {}'.format(args.output_file, args.op_set)

--- a/tools/keras_to_onnx.py
+++ b/tools/keras_to_onnx.py
@@ -3,38 +3,32 @@
 """
 Script to convert YOLO keras model to ONNX model
 """
-import os, sys, argparse
+import os
+import sys
+import argparse
+import shutil
+import subprocess
 from tensorflow.keras.models import load_model
-import keras2onnx
-import onnx
 
 sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..'))
 from common.utils import get_custom_objects
-
-#tf.enable_eager_execution()
-
-os.environ['TF_KERAS'] = '1'
-
-def onnx_convert(keras_model_file, output_file, op_set):
-    custom_object_dict = get_custom_objects()
-    model = load_model(keras_model_file, custom_objects=custom_object_dict)
-
-    # convert to onnx model
-    onnx_model = keras2onnx.convert_keras(model, model.name, custom_op_conversions=custom_object_dict, target_opset=op_set)
-
-    # save converted onnx model
-    onnx.save_model(onnx_model, output_file)
 
 
 def main():
     parser = argparse.ArgumentParser(argument_default=argparse.SUPPRESS, description='Convert YOLO tf.keras model to ONNX model')
     parser.add_argument('--keras_model_file', required=True, type=str, help='path to keras model file')
     parser.add_argument('--output_file', required=True, type=str, help='output onnx model file')
-    parser.add_argument('--op_set', required=False, type=int, help='onnx op set', default=None)
+    parser.add_argument('--op_set', required=False, type=int, help='onnx op set', default=10)
 
     args = parser.parse_args()
+    model = load_model(args.keras_model_file)
+    model.save('./tmp/')
 
-    onnx_convert(args.keras_model_file, args.output_file, args.op_set)
+    cmd = 'python -m tf2onnx.convert --saved_model ./tmp/ --output {} --opset {}'.format(args.output_file, args.op_set)
+    process = subprocess.Popen(cmd.split(), stdout=subprocess.PIPE)
+    output, error = process.communicate()
+
+    shutil.rmtree('./tmp/')
 
 
 if __name__ == '__main__':

--- a/tools/validate_yolo.py
+++ b/tools/validate_yolo.py
@@ -87,7 +87,7 @@ def validate_yolo_model_tflite(model_path, image_file, anchors, class_names, loo
     for output_detail in output_details:
         output_data = interpreter.get_tensor(output_detail['index'])
         prediction.append(output_data)
-
+    prediction.sort(key=lambda x: len(x[0]))
     handle_prediction(prediction, image_file, image, image_shape, anchors, class_names, model_image_size)
     return
 
@@ -323,6 +323,8 @@ def validate_yolo_model_onnx(model_path, image_file, anchors, class_names, loop_
     start = time.time()
     for i in range(loop_count):
         prediction = sess.run(None, feed)
+
+    prediction.sort(key=lambda x: len(x[0]))
     end = time.time()
     print("Average Inference time: {:.8f}ms".format((end - start) * 1000 /loop_count))
 


### PR DESCRIPTION
This PR will fix #39 partially. I have not added the K.softplus to its more basic K.log, K.exp form. The changes increases the GPU memory required for training. It is best to use K.softplus during training and replace it only during export.  